### PR TITLE
fix: 修复清除按钮的文字内容与右侧的边距和时间信息的边距不一致的问题

### DIFF
--- a/dde-clipboard/iconbutton.cpp
+++ b/dde-clipboard/iconbutton.cpp
@@ -76,6 +76,18 @@ void IconButton::paintEvent(QPaintEvent *event)
     }
 }
 
+QSize IconButton::sizeHint() const
+{
+    qDebug() << Q_FUNC_INFO;
+    return QSize(fontMetrics().width(m_text) + 20, fontMetrics().height() + 10);
+}
+
+void IconButton::resizeEvent(QResizeEvent *event)
+{
+    resize(QSize(fontMetrics().width(m_text) + 20, fontMetrics().height() + 10));
+    DWidget::resizeEvent(event);
+}
+
 /*!
  * \~chinese \name setFocusState
  * \~chinese \brief 控制按钮被选中时,设置m_hasFocus的状态

--- a/dde-clipboard/iconbutton.h
+++ b/dde-clipboard/iconbutton.h
@@ -69,6 +69,8 @@ protected:
      * \~chinese \param event 事件
      */
     virtual void leaveEvent(QEvent *event) override;
+    virtual void resizeEvent(QResizeEvent *event) override;
+    virtual QSize sizeHint() const override;
 };
 
 #endif // ICONBUTTON_

--- a/dde-clipboard/itemwidget.cpp
+++ b/dde-clipboard/itemwidget.cpp
@@ -237,6 +237,7 @@ void ItemWidget::initUI()
     titleLayout->setSpacing(0);
     titleLayout->setContentsMargins(10, 0, 10, 0);
     titleLayout->addWidget(m_nameLabel);
+    titleLayout->addStretch();
     titleLayout->addWidget(m_timeLabel);
     titleLayout->addWidget(m_closeButton);
 

--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -178,16 +178,18 @@ void MainWindow::initUI()
     QWidget *titleWidget = new QWidget;
     QHBoxLayout *titleLayout = new QHBoxLayout(titleWidget);
     titleLayout->setContentsMargins(20, 0, 10, 0);
+    titleLayout->setAlignment(Qt::AlignVCenter);
 
     QLabel *titleLabel = new QLabel(tr("Clipboard"), this);
-    titleLabel->setFont(DFontSizeManager::instance()->t3());
+    DFontSizeManager::instance()->bind(titleLabel, DFontSizeManager::T3);
 
     m_clearButton = new IconButton(tr("Clear all"), this);
     connect(m_clearButton, &IconButton::clicked, m_model, &ClipboardModel::clear);
 
     titleLayout->addWidget(titleLabel);
+    titleLayout->addStretch();
     titleLayout->addWidget(m_clearButton);
-    m_clearButton->setFixedSize(100, 36);
+    m_clearButton->setFixedHeight(36);
     m_clearButton->setBackOpacity(200);
     m_clearButton->setRadius(8);
     m_clearButton->setVisible(false);


### PR DESCRIPTION
调整清除按钮控件大小

Log: 修复清除按钮文字内容与右侧边距和时间的边距不一致的问题
Bug: https://pms.uniontech.com/bug-view-160153.html
Influence: 剪切板
Change-Id: Ib2afa54a07fbb04602f3e3280742e3e933517048