### PR TITLE
fix: wine应用截图时高概率出现系统卡死现象

### DIFF
--- a/dde-clipboard-daemon/readpipedatatask.cpp
+++ b/dde-clipboard-daemon/readpipedatatask.cpp
@@ -46,7 +46,6 @@ void ReadPipeDataTask::run()
 
     // 根据mime类取数据，写入pipe中
     m_pOffer->receive(m_mimeType, pipeFds[1]);
-    m_pConnectionThread->roundtrip();
     close(pipeFds[1]);
 
     QByteArray data;


### PR DESCRIPTION
去掉m_pConnectionThread->roundtrip，防止阻塞wayland的通讯

Log: 修复wine应用截图时高概率出现系统卡死现象的问题
Bug: https://pms.uniontech.com/bug-view-176907.html
Influence: wine应用截图