### PR TITLE
feat: add dbus window visible property and changed signal

### DIFF
--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -424,3 +424,15 @@ void MainWindow::paintEvent(QPaintEvent *e)
     p.setPen(pen);
     p.drawRoundedRect(rect(), m_cornerRadius, m_cornerRadius);
 }
+
+void MainWindow::showEvent(QShowEvent *event)
+{
+    Q_EMIT clipboardVisibleChanged(true);
+    QWidget::showEvent(event);
+}
+
+void MainWindow::hideEvent(QHideEvent *event)
+{
+    Q_EMIT clipboardVisibleChanged(false);
+    QWidget::hideEvent(event);
+}

--- a/dde-clipboard/mainwindow.h
+++ b/dde-clipboard/mainwindow.h
@@ -84,6 +84,9 @@ public Q_SLOTS:
     void Show();
     void Hide();
 
+Q_SIGNALS: // SIGNALS
+    void clipboardVisibleChanged(bool visible);
+
 private Q_SLOTS:
     /*!
      * \~chinese \name geometryChanged
@@ -103,6 +106,8 @@ private Q_SLOTS:
     void CompositeChanged();
 
     void registerMonitor();
+
+    bool clipboardVisible() const { return isVisible(); }
 
 private:
     /*!
@@ -140,6 +145,8 @@ protected:
      * \~chinese \brief 重写mouseMoveEvent事件禁止窗口被移动
      */
     virtual void mouseMoveEvent(QMouseEvent *event) override;
+    void showEvent(QShowEvent *event) override;
+    void hideEvent(QHideEvent *event) override;
 
 private:
     DBusDisplay *m_displayInter;

--- a/dde-clipboard/org.deepin.dde.Clipboard1.xml
+++ b/dde-clipboard/org.deepin.dde.Clipboard1.xml
@@ -7,5 +7,10 @@
     </method>
     <method name="Hide">
     </method>
+    <property name="clipboardVisible" access="read" type="b">
+    </property>
+    <signal name="clipboardVisibleChanged">
+        <arg type="b" name="visible"/>
+    </signal>
   </interface>
 </node>


### PR DESCRIPTION
dock-clipboard plugin need clipboard window's visible property.

Log: as title
Influence: dbus has visible property