### PR TITLE
fix: window removes its own display animation

### DIFF
--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -170,7 +170,8 @@ void MainWindow::setX(int x)
 
 void MainWindow::CompositeChanged()
 {
-    m_hasComposite = m_wmHelper->hasComposite();
+    // 屏蔽应用自己的动画，默认使用窗管窗口显示动画
+    m_hasComposite = false;
 }
 
 void MainWindow::registerMonitor()


### PR DESCRIPTION
as title

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/9728