### PR TITLE
fix: clipboard background transparent

### DIFF
--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -429,11 +429,11 @@ void MainWindow::paintEvent(QPaintEvent *e)
 void MainWindow::showEvent(QShowEvent *event)
 {
     Q_EMIT clipboardVisibleChanged(true);
-    QWidget::showEvent(event);
+    DBlurEffectWidget::showEvent(event);
 }
 
 void MainWindow::hideEvent(QHideEvent *event)
 {
     Q_EMIT clipboardVisibleChanged(false);
-    QWidget::hideEvent(event);
+    DBlurEffectWidget::hideEvent(event);
 }


### PR DESCRIPTION
Modify setFixedWidth to 0

Log: clipboard background transparent
But: https://pms.uniontech.com/bug-view-271347.html