### PR TITLE
chore: remove startdde dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-clipboard (1:6.1.7) unstable; urgency=medium
+
+  * chore: remove startdde dependency
+
+ -- fuleyi <fuleyi@uniontech.com>  Wed, 02 Apr 2025 11:26:28 +0800
+
 dde-clipboard (1:6.1.6) unstable; urgency=medium
 
   * fix: double click can't select item

--- a/debian/control
+++ b/debian/control
@@ -35,8 +35,7 @@ Package: dde-clipboard
 Architecture: any
 Depends: ${shlibs:Depends},
  ${misc:Depends},
- dde-daemon (>=5.12.0.31),
- startdde (>=5.6.0.34),
+ dde-daemon (>=6.1.26),
  dde-api (>=2.92.1),
  dde-session (>=1.1.5)
 Description: deepin desktop-environment - clipboard module


### PR DESCRIPTION
remove startdde dependency

Log: remove startdde dependency
pms: TASK-374777

## Summary by Sourcery

Chores:
- Remove startdde dependency from the project's Debian packaging configuration