### PR TITLE
fix: update dde-clipboard-daemon service dependencies

### DIFF
--- a/misc/dde-clipboard-daemon.service.in
+++ b/misc/dde-clipboard-daemon.service.in
@@ -1,5 +1,11 @@
 [Unit]
 Description=dde-clipboard-daemon
+Requisite=dde-session-pre.target
+After=dde-session-pre.target
+
+Requisite=dde-session-initialized.target
+PartOf=dde-session-initialized.target
+Before=dde-session-initialized.target
 StartLimitBurst=3
 
 [Service]


### PR DESCRIPTION
1. Added Requisite and After directives for dde-session-pre.target
2. Added Requisite, PartOf and Before directives for dde-session-
initialized.target
3. These changes ensure proper service ordering and dependencies in the
DDE session startup sequence
4. Prevents potential race conditions during system initialization

fix: 更新 dde-clipboard-daemon 服务依赖关系
系统注销时session退出，xorg先于dde-clipboard-daemon退出，导致其systemd
中的service重启机制起作用，在没有进入session的时候仍然尝试重启，导致无法
连接上xserver（在greeter阶段，还未认证）

1. 为 dde-session-pre.target 添加了 Requisite 和 After 指令
2. 为 dde-session-initialized.target 添加了 Requisite, PartOf 和 Before
指令
3. 这些更改确保在 DDE 会话启动序列中有正确的服务顺序和依赖关系
4. 防止系统初始化期间可能出现的竞争条件

pms: BUG-313613

## Summary by Sourcery

Update systemd service dependencies for dde-clipboard-daemon to improve startup reliability and prevent initialization issues during the DDE session startup sequence

Bug Fixes:
- Prevent dde-clipboard-daemon from restarting inappropriately during system logout and before session authentication

Chores:
- Modify systemd service configuration to ensure proper service ordering