### PR TITLE
chore: bump version to 1:6.1.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-clipboard (1:6.1.8) unstable; urgency=medium
+
+  * fix: update dde-clipboard-daemon service dependencies
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 08 May 2025 17:43:38 +0800
+
 dde-clipboard (1:6.1.7) unstable; urgency=medium
 
   * chore: remove startdde dependency


### PR DESCRIPTION
update changelog to 1:6.1.8

## Summary by Sourcery

Chores:
- Update Debian package changelog to new version 1:6.1.8