### PR TITLE
fix: enhance build security hardening options

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,10 @@
 include /usr/share/dpkg/default.mk
 
 export QT_SELECT = qt6
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 %:
 	dh $@ --parallel


### PR DESCRIPTION
1. Added DEB_BUILD_MAINT_OPTIONS with hardening=+all for comprehensive security hardening
2. Appended warning flags (-Wall) to C/C++ compiler flags for better code quality checks
3. Added security-focused linker flags including RELRO, immediate binding, and noexecstack protection
4. Maintained Qt6 selection while improving overall build security posture
5. These changes align with Debian security best practices for package building

fix: 增强构建安全加固选项

1. 添加 DEB_BUILD_MAINT_OPTIONS 并设置 hardening=+all 以实现全面的安全 加固
2. 向 C/C++ 编译器标志追加警告标志 (-Wall) 以提高代码质量检查
3. 添加安全相关的链接器标志，包括 RELRO、立即绑定和 noexecstack 保护
4. 在保持 Qt6 选择的同时提升整体构建安全性
5. 这些变更符合 Debian 软件包构建的安全最佳实践