### PR TITLE
chore: bump version to 6.1.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-clipboard (1:6.1.10) unstable; urgency=medium
+
+  * fix: enhance build security hardening options
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 03 Jul 2025 19:57:07 +0800
+
 dde-clipboard (1:6.1.9) unstable; urgency=medium
 
   * chore: remove unused Spanish translation file


### PR DESCRIPTION
update changelog to 6.1.10

## Summary by Sourcery

Chores:
- Update Debian changelog entry to version 6.1.10.