### PR TITLE
fix: make coverage compilation conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ set(BIN_NAME dde-clipboard)
 
 project(${BIN_NAME})
 
+option(ENABLE_COV "Enable code coverage" OFF)
+
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -221,7 +223,9 @@ add_executable(${UT_BIN_NAME}
     ${DBUS_TYPES}
 )
 # 用于测试覆盖率的编译条件
-target_compile_options(${UT_BIN_NAME} PRIVATE -fprofile-arcs -ftest-coverage)
+if (ENABLE_COV)
+    target_compile_options(${UT_BIN_NAME} PRIVATE -fprofile-arcs -ftest-coverage)
+endif()
 
 target_link_libraries(${UT_BIN_NAME} PRIVATE
     Dtk${DTK_VERSION_MAJOR}::Widget

--- a/tests/test-recoverage.sh
+++ b/tests/test-recoverage.sh
@@ -9,7 +9,7 @@ rm -rf $BUILD_DIR
 mkdir $BUILD_DIR
 cd $BUILD_DIR
 
-cmake -DCMAKE_BUILD_TYPE=Debug ..
+cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_COV=ON ..
 make -j 8
 
 mkdir -p ../tests/$HTML_DIR


### PR DESCRIPTION
The coverage compilation flags (-fprofile-arcs -ftest-coverage) were
causing non-deterministic test behavior because they were always enabled
for unit tests. This made test results non-repeatable as coverage
instrumentation affects program execution.

Added ENABLE_COV option to CMake to control coverage compilation
Wrapped coverage flags in conditional check that only enables them when
ENABLE_COV=ON
Updated test-recoverage.sh script to explicitly enable coverage with
-DENABLE_COV=ON

Log: Fixed unit test non-repeatability issue caused by coverage
instrumentation

Influence:
1. Run unit tests with ENABLE_COV=OFF to verify deterministic behavior
2. Run unit tests with ENABLE_COV=ON to confirm coverage still works
3. Test that the same test inputs produce identical results across
multiple runs
4. Verify coverage reports are generated only when explicitly enabled
5. Check that default build configuration has coverage disabled

fix: 修复覆盖率参数导致的单元测试不可重复问题

覆盖率编译标志(-fprofile-arcs -ftest-coverage)一直为单元测试启用，导致测
试行为不确定。覆盖率检测会影响程序执行，使得测试结果不可重复。

在CMake中添加ENABLE_COV选项来控制覆盖率编译
将覆盖率标志包装在条件检查中，仅在ENABLE_COV=ON时启用
更新test-recoverage.sh脚本，明确使用-DENABLE_COV=ON启用覆盖率

Log: 修复了覆盖率检测导致的单元测试不可重复性问题

Influence:
1. 使用ENABLE_COV=OFF运行单元测试，验证确定性行为
2. 使用ENABLE_COV=ON运行单元测试，确认覆盖率功能仍然正常工作
3. 测试相同的输入在多轮运行中是否产生相同的结果
4. 验证覆盖率报告仅在明确启用时生成
5. 检查默认构建配置是否已禁用覆盖率

## Summary by Sourcery

Make coverage instrumentation in CMake opt-in via a new ENABLE_COV flag and update the test-recoverage script accordingly to restore deterministic test behavior and generate coverage reports only when requested.

Bug Fixes:
- Fix nondeterministic unit test behavior caused by always-on coverage instrumentation

Enhancements:
- Add ENABLE_COV CMake option to control coverage compilation
- Conditionally apply coverage compilation flags only when ENABLE_COV is ON

Tests:
- Update test-recoverage.sh to explicitly enable coverage with -DENABLE_COV=ON