### PR TITLE
chore: bump version to 6.1.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-clipboard (1:6.1.11) unstable; urgency=medium
+
+  * Updates for project Deepin Desktop Environment (#200)
+  * i18n: Updates for project Deepin Desktop Environment (#199)
+  * chore: update configurations for REUSE and tx-cli
+  * chore: update translations from Transifex
+  * chore: Optimize packaging (#198)
+  * fix: make coverage compilation conditional
+
+ -- Kun Zhang <zhangkun2@uniontech.com>  Thu, 03 Jul 2025 19:57:07 +0800
+
 dde-clipboard (1:6.1.10) unstable; urgency=medium
 
   * fix: enhance build security hardening options


### PR DESCRIPTION
update changelog to 6.1.11

## Summary by Sourcery

Chores:
- Update Debian changelog entry for version 6.1.11