### PR TITLE
fix: adjust window positioning for right dock

### DIFF
--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -96,12 +96,12 @@ void MainWindow::geometryChanged()
         switch (m_daemonDockInter->position()) {
             case DOCK_TOP: margins.setTop(dockGeometry.height() + WindowMargin); break;
             case DOCK_BOTTOM: margins.setBottom(dockGeometry.height() + WindowMargin); break;
-            case DOCK_LEFT: margins.setLeft(dockGeometry.width() + WindowMargin); break;
-            case DOCK_RIGHT: break;
+            case DOCK_LEFT: break;
+            case DOCK_RIGHT: margins.setRight(dockGeometry.width() + WindowMargin); break;
         }
     }
 
-    layerShellWnd->setLeftMargin(margins.left());
+    layerShellWnd->setRightMargin(margins.right());
     layerShellWnd->setBottomMargin(margins.bottom());
     layerShellWnd->setTopMargin(margins.top());
 
@@ -270,7 +270,7 @@ void MainWindow::initUI()
     // LayerShell-implemented anchoring
     auto layerShellWnd = ds::DLayerShellWindow::get(windowHandle());
 
-    layerShellWnd->setAnchors({ ds::DLayerShellWindow::AnchorLeft,
+    layerShellWnd->setAnchors({ ds::DLayerShellWindow::AnchorRight,
                                 ds::DLayerShellWindow::AnchorBottom,
                                 ds::DLayerShellWindow::AnchorTop });
     layerShellWnd->setLayer(ds::DLayerShellWindow::LayerOverlay);


### PR DESCRIPTION
Fixed window positioning logic to correctly handle when the system dock
is positioned on the right side. Previously, the margins and anchors
were incorrectly configured for right dock positioning, causing the
clipboard window to appear in the wrong location when the dock was on
the right side of the screen.

The changes include:
1. Swapped margin handling: removed left margin calculation and added
right margin calculation for DOCK_RIGHT case
2. Updated layer shell window to set right margin instead of left margin
3. Changed window anchors from AnchorLeft to AnchorRight to properly
anchor the window to the right side of the screen

Log: Fixed clipboard window positioning when system dock is on the right
side

Influence:
1. Test clipboard window positioning with dock on right side of screen
2. Verify window appears correctly spaced from right dock
3. Test with dock in other positions (top, bottom, left) to ensure no
regression
4. Verify window anchoring behavior in all dock configurations
5. Check window margins are properly calculated for each dock position

fix: 调整右侧任务栏时的窗口定位

修复了当系统任务栏位于右侧时的窗口定位逻辑。之前右侧任务栏定位的边距和锚
点配置不正确，导致任务栏在屏幕右侧时剪贴板窗口出现在错误位置。

具体修改包括：
1. 交换边距处理：移除左侧边距计算，为右侧任务栏情况添加右侧边距计算
2. 更新图层shell窗口以设置右侧边距而非左侧边距
3. 将窗口锚点从左锚点改为右锚点，使窗口正确锚定到屏幕右侧

Log: 修复系统任务栏在右侧时剪贴板窗口的定位问题

Influence:
1. 测试任务栏在右侧时的剪贴板窗口定位
2. 验证窗口与右侧任务栏的正确间距
3. 测试任务栏在其他位置（顶部、底部、左侧）时的表现，确保没有回归问题
4. 验证所有任务栏配置下的窗口锚定行为
5. 检查每种任务栏位置下的窗口边距计算是否正确

PMS: STORY-39313

## Summary by Sourcery

Fix clipboard window positioning when the system dock is on the right side by adjusting margin calculations and window anchors.

Bug Fixes:
- Correct margin calculation for right dock scenarios and apply right margin instead of left.
- Update window anchoring to use right anchors for proper positioning alongside the right dock.