### PR TITLE
fix: correct scaling position calculation

### DIFF
--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -90,6 +90,13 @@ void MainWindow::geometryChanged()
     auto layerShellWnd = ds::DLayerShellWindow::get(windowHandle());
     QMargins margins(WindowMargin, WindowMargin, WindowMargin, WindowMargin);
     auto dockGeometry = m_daemonDockInter->frontendWindowRect();
+    // frontendWindowRect is physical screen rect, we need to convert it to logical screen rect.
+    dockGeometry = QRect(
+        dockGeometry.x() / qApp->devicePixelRatio(),
+        dockGeometry.y() / qApp->devicePixelRatio(),
+        dockGeometry.width() / qApp->devicePixelRatio(),
+        dockGeometry.height() / qApp->devicePixelRatio()
+    );
 
     // dock not hide and in current screen
     if (m_daemonDockInter->hideState() != 2 && (window() && window()->screen()->geometry().contains(dockGeometry))) {


### PR DESCRIPTION
Fixed incorrect position calculation when scaling is applied. The
frontendWindowRect returns physical screen coordinates but the
application uses logical coordinates. Added conversion from physical
to logical coordinates by dividing by the device pixel ratio to ensure
proper positioning relative to the dock.

Log: Fixed clipboard window position calculation under screen scaling

Influence:
1. Test clipboard window positioning with different screen scaling
factors
2. Verify window appears correctly when dock is visible and hidden
3. Test on multi-monitor setups with varying DPI settings
4. Check that window margins are maintained properly after scaling
conversion

fix: 修复缩放位置计算错误

修复了应用缩放时位置计算错误的问题。frontendWindowRect 返回的是物理屏幕
坐标，但应用程序使用的是逻辑坐标。添加了从物理坐标到逻辑坐标的转换，通过
除以设备像素比来确保相对于任务栏的正确定位。

Log: 修复屏幕缩放下剪贴板窗口位置计算问题

Influence:
1. 测试不同屏幕缩放比例下的剪贴板窗口定位
2. 验证任务栏显示和隐藏时窗口位置是否正确
3. 在具有不同DPI设置的多显示器配置中测试
4. 检查缩放转换后窗口边距是否正确保持

PMS: BUG-300979
