### PR TITLE
fix: clipboard transparent issue on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,16 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.deepin.dde.Clipboard1.service DEST
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dde-clipboard.service DESTINATION ${SYSTEMD_USER_UNIT_DIR})
 
-install_symlink(dde-clipboard.service dde-session-initialized.target.wants)
+# XDG autostart 替代 systemd wants 自动启动，保留 systemd service 作为 D-Bus 激活
+# install_symlink(dde-clipboard.service dde-session-initialized.target.wants)
+
+configure_file(
+    misc/dde-clipboard.desktop.in
+    dde-clipboard.desktop
+    @ONLY
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dde-clipboard.desktop DESTINATION /etc/xdg/autostart)
 
 ## dsg config
 # Collect all dconfig configuration files

--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -663,6 +663,14 @@ void MainWindow::showEvent(QShowEvent *event)
 {
     Q_EMIT clipboardVisibleChanged(true);
     DBlurEffectWidget::showEvent(event);
+
+    static bool firstShow = true;
+    if (firstShow) {
+        firstShow = false;
+        m_windowHandle->setEnableBlurWindow(false);
+        m_windowHandle->setEnableBlurWindow(true);
+    }
+
     activateWindow();
 }
 
@@ -740,4 +748,16 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
         }
     }
     return DBlurEffectWidget::eventFilter(watched, event);
+}
+
+void MainWindow::resizeEvent(QResizeEvent *event)
+{
+    DBlurEffectWidget::resizeEvent(event);
+
+    static bool firstResize = true;
+    if (firstResize) {
+        firstResize = false;
+        m_windowHandle->setEnableBlurWindow(false);
+        m_windowHandle->setEnableBlurWindow(true);
+    }
 }

--- a/dde-clipboard/mainwindow.h
+++ b/dde-clipboard/mainwindow.h
@@ -70,6 +70,7 @@ protected:
     void hideEvent(QHideEvent *event) override;
     bool event(QEvent *event) override;
     bool eventFilter(QObject *watched, QEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
 signals:
     void OpacityChanged(double value) const;

--- a/debian/dde-clipboard.conffiles
+++ b/debian/dde-clipboard.conffiles
@@ -1,2 +1,1 @@
-remove-on-upgrade /etc/xdg/autostart/dde-clipboard.desktop
 remove-on-upgrade /etc/xdg/autostart/dde-clipboard-daemon.desktop

--- a/misc/dde-clipboard.desktop.in
+++ b/misc/dde-clipboard.desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Deepin Clipboard
+Comment=Deepin Clipboard
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/dde-clipboard
+NoDisplay=true
+OnlyShowIn=DDE
+Type=Application
+X-Deepin-Vendor=user-custom
+X-Deepin-TurboType=dtkwidget


### PR DESCRIPTION
1. Replace systemd want symlink with XDG autostart desktop file for more reliable clipboard service startup
2. Add blur window re-init workaround in showEvent and resizeEvent to fix transparency issue on first display
3. Remove old conffiles entry for dde-clipboard.desktop as it's now managed by XDG autostart

Log: Fixed clipboard window transparent display on first startup

Influence:
1. Verify clipboard window appears correctly without transparency on startup
2. Test clipboard window after resize to ensure no transparency issues
3. Verify clipboard service starts automatically via XDG autostart
4. Test clipboard functionality after system restart
5. Check that clipboard window still works properly after manual launch

fix: 修复剪切板启动透明问题

1. 将 systemd want 符号链接替换为 XDG autostart 桌面文件，使剪切板服务启 动更可靠
2. 在 showEvent 和 resizeEvent 中添加模糊窗口重新初始化处理，修复首次显 示时的透明度问题
3. 移除旧的 conffiles 中 dde-clipboard.desktop 条目，现在由 XDG autostart 管理

Log: 修复剪切板首次启动窗口透明问题

Influence:
1. 验证剪切板窗口启动时无透明问题
2. 测试调整窗口大小后无透明度异常
3. 验证剪切板服务通过 XDG autostart 自动启动
4. 测试系统重启后的剪切板功能
5. 检查手动启动剪切板窗口是否能正常工作

PMS: BUG-362049
Change-Id: Ida2a9ef6aa4f301684810067832fd30771a483eb

## Summary by Sourcery

Resolve clipboard window transparency on first display and switch clipboard autostart to XDG desktop entry instead of a systemd wants symlink.

Bug Fixes:
- Ensure the clipboard window initializes its blur effect correctly on first show and after the first resize to avoid transparent display.

Build:
- Install an XDG autostart desktop file for dde-clipboard and stop creating the systemd wants symlink, keeping the systemd user service only for D-Bus activation.

Chores:
- Update packaging by removing the old conffiles entry for dde-clipboard.desktop now that it is managed via XDG autostart.