### PR TITLE
chore: update changelog to 1:6.1.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-clipboard (1:6.1.28) unstable; urgency=medium
+
+  * fix: clipboard transparent issue on startup
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 22 May 2026 18:10:31 +0800
+
 dde-clipboard (1:6.1.27) unstable; urgency=medium
 
   * fix: Fix the clipboard tab key switching focus issue


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1:6.1.28

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1:6.1.28
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog entries to reflect version 1:6.1.28 targeting master.