### PR TITLE
[暂不合并]feat(service): disable THP before clipboard service startup

### DIFF
--- a/misc/dde-clipboard-daemon.service.in
+++ b/misc/dde-clipboard-daemon.service.in
@@ -10,6 +10,7 @@ StartLimitBurst=3
 [Service]
 Type=dbus
 BusName=org.deepin.dde.daemon.Clipboard1
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/dde-clipboard-daemon
 Slice=session.slice
 Restart=on-failure

--- a/misc/dde-clipboard.service.in
+++ b/misc/dde-clipboard.service.in
@@ -11,6 +11,7 @@ StartLimitBurst=3
 [Service]
 Type=dbus
 BusName=org.deepin.dde.Clipboard1
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/dde-clipboard
 Slice=session.slice
 Restart=always


### PR DESCRIPTION
1. Add ExecStartPre script to disable Transparent Huge Pages before dde-clipboard-daemon and dde-clipboard services start
2. Use leading dash (-) to allow service startup even if THP disable script fails

Log: Disable THP before clipboard services start to improve performance

feat(service): 剪切板服务启动前禁用透明大页

1. 在 dde-clipboard-daemon 和 dde-clipboard 两个服务中增加 ExecStartPre 脚本，启动前禁用透明大页
2. 使用前置短横线 (-) 确保即使脚本失败也不影响服务正常启动

Log: 剪切板服务启动前禁用透明大页以提升性能
PMS: TASK-390043

## Summary by Sourcery

Enhancements:
- Add a pre-start step to dde-clipboard-daemon and dde-clipboard systemd services to disable Transparent Huge Pages before service startup.