### PR TITLE
chore: update changelog to 1:6.1.29

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-clipboard (1:6.1.29) unstable; urgency=medium
+
+  * fix: Avoid manual dock margins on Wayland
+  * fix: Let notification center use Wayland exclusive zones
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 19:45:36 +0800
+
 dde-clipboard (1:6.1.28) unstable; urgency=medium
 
   * fix: clipboard transparent issue on startup


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1:6.1.29

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1:6.1.29
- 目标分支: master

## Summary by Sourcery

Documentation:
- Update debian/changelog with entry for version 1:6.1.29.