### PR TITLE
fix: use application theme window radius and listen for changes

### DIFF
--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -17,6 +17,7 @@
 
 #include <DFontSizeManager>
 #include <DGuiApplicationHelper>
+#include <DPlatformTheme>
 #include <DIcon>
 #include <DDciIcon>
 #include <DConfig>
@@ -401,7 +402,11 @@ void MainWindow::initUI()
     m_trickTimer->setInterval(300);
     m_trickTimer->setSingleShot(true);
 
-    m_cornerRadius = m_windowHandle->windowRadius();
+    // 从应用主题获取圆角值并设置到窗口
+    DPlatformTheme *theme = DGuiApplicationHelper::instance()->applicationTheme();
+    m_cornerRadius = theme->windowRadius();
+    m_windowHandle->setWindowRadius(m_cornerRadius);
+
     m_themeType= DGuiApplicationHelper::instance()->themeType();
     m_windowHandle->setBorderWidth(1);
 
@@ -557,6 +562,16 @@ void MainWindow::initConnect()
             return;
 
         m_cornerRadius = m_windowHandle->windowRadius();
+        update();
+    });
+
+    // 监听应用主题圆角变化
+    DPlatformTheme *theme = DGuiApplicationHelper::instance()->applicationTheme();
+    connect(theme, &DPlatformTheme::windowRadiusChanged, this, [this](int newRadius){
+        if (m_cornerRadius == newRadius)
+            return;
+        m_cornerRadius = newRadius;
+        m_windowHandle->setWindowRadius(m_cornerRadius);
         update();
     });
 


### PR DESCRIPTION
## 变更说明

使用应用主题设置窗口圆角并监听变化

### 修改内容

1. 从 `DGuiApplicationHelper::applicationTheme()` 获取 `windowRadius`
2. 通过 `DPlatformWindowHandle::setWindowRadius()` 设置窗口圆角
3. 监听 `DPlatformTheme::windowRadiusChanged` 信号实时更新

### 测试验证

1. 验证窗口圆角与当前应用主题设置一致
2. 测试应用主题更新时圆角变化
3. 验证圆角实时应用到窗口
4. 检查圆角变化过程中无视觉异常

### 关联 Issues

- PMS: [BUG-289145](https://pms.uniontech.com/bug-view-289145.html)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align window corner radius with the current application theme and keep it in sync with theme changes.

Enhancements:
- Initialize the main window's corner radius from the application theme instead of the window handle default.
- Automatically update the window's corner radius when the application theme's window radius setting changes.