### PR TITLE
chore: update changelog to 1:6.1.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-clipboard (1:6.1.30) unstable; urgency=medium
+
+  * fix: use application theme window radius and listen for changes
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 17:13:34 +0800
+
 dde-clipboard (1:6.1.29) unstable; urgency=medium
 
   * fix: Avoid manual dock margins on Wayland


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1:6.1.30

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1:6.1.30
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog entry for release 1:6.1.30.