### PR TITLE
fix: delegate autostart to systemd for reliable restart

### DIFF
--- a/misc/dde-clipboard.desktop.in
+++ b/misc/dde-clipboard.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Deepin Clipboard
 Comment=Deepin Clipboard
-Exec=@CMAKE_INSTALL_FULL_BINDIR@/dde-clipboard
+Exec=systemctl --user start dde-clipboard.service
 NoDisplay=true
 OnlyShowIn=DDE
 Type=Application


### PR DESCRIPTION
Changed the XDG autostart desktop file to use `systemctl --user start dde-clipboard.service` instead of directly executing the binary. This ensures the clipboard process is managed by systemd, so Restart=always in the service file takes effect when the process is killed.

Log: Fixed clipboard not restarting after being killed when started via XDG autostart

Influence:
1. Test killing dde-clipboard process and verify it restarts automatically
2. Verify clipboard functionality continues working after restart
3. Test system startup to ensure clipboard service starts properly
4. Verify clipboard window appears correctly without transparency issues

fix: 通过 systemd 托管 autostart 启动，修复 kill 后无法自动重启

将 XDG autostart 桌面文件的 Exec 改为使用 `systemctl --user start dde-clipboard.service` 而非直接执行二进制文件。这样剪贴板进程由
systemd 管理，确保服务文件中的 Restart=always 在进程被杀死后生效。

Log: 修复剪切板通过 XDG autostart 启动后被杀死无法自动重启的问题

Influence:
1. 测试手动杀死 dde-clipboard 进程并验证其自动重启
2. 验证剪贴板功能在服务重启后继续正常工作
3. 测试系统启动时剪贴板服务是否正确启动
4. 验证剪切板窗口启动时无透明问题

PMS: BUG-365901

## Summary by Sourcery

Bug Fixes:
- Ensure dde-clipboard automatically restarts when started via XDG autostart and the process is killed.