### PR TITLE
fix(clipboard): fix jagged image under fractional scaling

### DIFF
--- a/dde-clipboard/constants.h
+++ b/dde-clipboard/constants.h
@@ -5,6 +5,7 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
+#include <QGuiApplication>
 #include <QSize>
 #include <QPixmap>
 #include <QPainter>
@@ -106,9 +107,9 @@ inline QPixmap GetRoundPixmap(const QPixmap &pix, QColor borderColor)
     }
 
     const int radius = 10;
-    const qreal borderWidth = 4.0;
+    const qreal borderWidth = 3.0;
 
-    const qreal dpr = pix.devicePixelRatioF();
+    const qreal dpr = qGuiApp ? qGuiApp->devicePixelRatio() : pix.devicePixelRatioF();
     const QSize logicalSize = pix.size();
 
     QImage target(logicalSize * dpr, QImage::Format_ARGB32_Premultiplied);


### PR DESCRIPTION
1. Include QGuiApplication header for qGuiApp global pointer
2. Reduce border width from 4.0 to 3.0 for cleaner appearance
3. Use qGuiApp->devicePixelRatio() to get screen DPR instead of pixmap's potentially inaccurate devicePixelRatioF()

Log: Fix jagged edges in clipboard images at non-100% display scale ratios

fix(clipboard): 修复缩放比下剪贴板图片锯齿问题

1. 添加 QGuiApplication 头文件以使用 qGuiApp 全局指针
2. 将边框宽度从 4.0 调整为 3.0，改善视觉效果
3. 使用 qGuiApp->devicePixelRatio() 获取屏幕 DPR，替代 pixmap 自身可能不准确的 devicePixelRatioF()

Log: 修复非 100% 缩放比下剪贴板图片锯齿明显的问题
PMS: BUG-315075

## Summary by Sourcery

Adjust clipboard image rendering to improve visual quality under fractional display scaling.

Bug Fixes:
- Correct device pixel ratio handling when generating rounded clipboard pixmaps to avoid jagged edges at non-100% scaling.

Enhancements:
- Tweak rounded pixmap border thickness for a cleaner clipboard image appearance.