### PR TITLE
fix(dde-clipboard): fix clipboard flicker and misalignment in extende…

### DIFF
--- a/dde-clipboard/mainwindow.cpp
+++ b/dde-clipboard/mainwindow.cpp
@@ -144,10 +144,27 @@ void MainWindow::onFrontendWindowRectChanged(const QRect &rect)
     // Check if dock has moved to a different screen
     QScreen *currentScreen = window()->screen();
     QScreen *targetScreen = screenForDockCenter(rect);
+
+    int dockFullSize = m_daemonDockInter->displayMode() == 0
+        ? m_daemonDockInter->windowSizeFashion()
+        : m_daemonDockInter->windowSizeEfficient();
     
     // If dock has moved to a different screen, update the window screen
     if (targetScreen != currentScreen) {
-        window()->setScreen(targetScreen);
+        // Determine whether the dock has moved to another screen. 
+        // Only when the dock has moved to another screen, should 
+        // the clipboard window be set to the other screen.
+        QPoint dockCenter = rect.center() / qApp->devicePixelRatio();
+        QRect currentGeo = currentScreen->geometry();
+        int dist = 0;
+        switch (m_daemonDockInter->position()) {
+            case DOCK_TOP:    dist = currentGeo.top() - dockCenter.y(); break;
+            case DOCK_BOTTOM: dist = dockCenter.y() - currentGeo.bottom(); break;
+            case DOCK_LEFT:   dist = currentGeo.left() - dockCenter.x(); break;
+            case DOCK_RIGHT:  dist = dockCenter.x() - currentGeo.right(); break;
+        }
+        if (dist >= dockFullSize)
+            window()->setScreen(targetScreen);
     }
 
     QRect dockGeometry = QRect(


### PR DESCRIPTION
…d mode

1. Calculate dock full size based on current display mode
2. Compute distance from dock center to current screen edge
3. Only switch window screen when dock has fully moved to new screen
4. Prevent clipboard window from jumping back and forth between screens

Log: Fix clipboard flickering and misalignment in multi-screen extended mode

fix(dde-clipboard): 修复多屏扩展下剪贴板闪动错位问题

1. 根据当前显示模式计算 dock 完整尺寸
2. 计算 dock 中心到当前屏幕边缘的距离
3. 仅在 dock 完全移动到新屏幕时才切换窗口屏幕
4. 防止剪贴板窗口在屏幕间来回跳动

Log: 修复多屏扩展模式下剪贴板闪动和错位的问题
PMS: BUG-368123